### PR TITLE
Build docs on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - all
+    - requirements: doc/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -300,3 +300,13 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'statsmodels': ('https://www.statsmodels.org/stable/', None)
 }
+
+# Build notebooks if on Read the Docs
+import subprocess
+if os.getenv("READTHEDOCS") == "True":
+    print("Processing notebooks, please wait...")
+    nb_output = subprocess.check_output(
+        ["make", "notebooks"],
+        env={"NB_KERNEL": "python3", "PATH": os.environ["PATH"]},
+    )
+    print(nb_output.decode(errors="ignore"))

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -301,12 +301,21 @@ intersphinx_mapping = {
     'statsmodels': ('https://www.statsmodels.org/stable/', None)
 }
 
-# Build notebooks if on Read the Docs
+# Build notebooks and thumbnails here if on Read the Docs
+# The rest of the build process is done by the actual sphinx command
 import subprocess
 if os.getenv("READTHEDOCS") == "True":
     print("Processing notebooks, please wait...")
     nb_output = subprocess.check_output(
         ["make", "notebooks"],
         env={"NB_KERNEL": "python3", "PATH": os.environ["PATH"]},
+    )
+    print(nb_output.decode(errors="ignore"))
+
+    print("Calling 'make html' first time to generate thumbnails, "
+          "see https://github.com/mwaskom/seaborn/issues/2532")
+    nb_output = subprocess.check_output(
+        ["make", "html"],
+        env={"PATH": os.environ["PATH"]},
     )
     print(nb_output.decode(errors="ignore"))


### PR DESCRIPTION
This _almost_ works:

https://astrojuanlu-seaborn.readthedocs.io/en/rtd/

However, the examples gallery doesn't. This is because the actual command to build the docs is this:

```
$ NB_KERNEL=python3 make notebooks html
```

or, alternatively (pseudo-bash):

```
$ ./tools/nb_to_doc.py tutorial/*.ipynb
$ ./tools/nb_to_doc.py docstrings/*.ipynb && cp -r $*_files ../generated/ && ...  # The "Examples" part of the docstrings
$ ./tools/nb_to_doc.py introduction.ipynb
$ make html
```

Looks like parts of this could be replaced by something like https://nbsphinx.readthedocs.io/, however it requires some workflow changes.